### PR TITLE
ci: fix goreleaser deprecations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: 2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,9 +12,9 @@ builds:
   - env:
       - CGO_ENABLED=0
     goos:
+      - darwin
       - linux
       - windows
-      - darwin
     goarch:
       - amd64
       - arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,9 @@ archives:
   - id: lancache-diagnostics
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     formats: [ 'tar.gz' ]
+    format_overrides:
+      - goos: windows
+        formats: [ "zip" ]
 
 builds:
   - env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ project_name: lancache-diagnostics
 archives:
   - id: lancache-diagnostics
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-    format: tar.gz
+    formats: [ 'tar.gz' ]
 
 builds:
   - env:
@@ -28,4 +28,4 @@ changelog:
       - '^test:'
 
 snapshot:
-  name_template: "{{ .ProjectName }}-v{{ incpatch .Version }}"
+  version_template: "{{ .ProjectName }}-v{{ incpatch .Version }}"


### PR DESCRIPTION
This change adjusts the GoReleaser configuration to remove deprecated flags with their new variants.