### PR TITLE
ci: fix goreleaser warning and changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 project_name: lancache-diagnostics
+version: 2
 
 archives:
   - id: lancache-diagnostics
@@ -27,6 +28,7 @@ changelog:
   sort: asc
   filters:
     exclude:
+      - '^build'
       - '^docs:'
       - '^test:'
 


### PR DESCRIPTION
This change adjusts GoReleaser to resolve a configuration related warning and excludes any commits prefixed with `build` from the resultant release changelog.